### PR TITLE
Improve the speed of plot-ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,13 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.lock
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ diffimg
 cartopy
 matplotlib
 numpy
+ffmpeg
 pygmt
 pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git
 source_modelling @ git+https://github.com/ucgmsim/source_modelling.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ diffimg
 cartopy
 matplotlib
 numpy
-ffmpeg
+ffmpeg-python
 pygmt
 pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git
 source_modelling @ git+https://github.com/ucgmsim/source_modelling.git

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -518,7 +518,7 @@ def animate_low_frequency(
     zoom: Annotated[float, typer.Option()] = 1,
     simple_map: Annotated[bool, typer.Option()] = False,
     map_quality: Annotated[int, typer.Option()] = 4,
-    downsample: int = 1
+    downsample: Annotated[int, typer.Option()] = 1
 ) -> None:
     """Render low-frequency output as a 2D video of ground motions.
 

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -493,7 +493,9 @@ def render_single_frame(
     # Save the frame to a file
     with io.BytesIO() as io_buf:
         fig.savefig(io_buf, format='raw', dpi=dpi)
+        fig.close()
         return io_buf.getvalue()
+
 
 @cli.from_docstring(app, name="xyts")
 def animate_low_frequency(

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -2,6 +2,7 @@
 
 import functools
 import multiprocessing as mp
+import io
 import os
 import shutil
 import subprocess
@@ -19,6 +20,7 @@ matplotlib.use("Agg")
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
+import ffmpeg
 import shapely
 import tqdm
 import typer
@@ -355,7 +357,7 @@ def render_single_frame(
     height: float,
     dpi: int,
     downsample: int
-) -> str:
+) -> bytes:
     """Render a single frame of the animation.
 
     Parameters
@@ -401,8 +403,8 @@ def render_single_frame(
 
     Returns
     -------
-    str
-        The filename of the saved frame.
+    bytes
+        The raw frame output for the frame index
     """
     xyts_file = XYTSFile(xyts_file_path)
     # Create a new figure for this frame
@@ -489,12 +491,9 @@ def render_single_frame(
     cbar.set_label("Ground Motion (cm/s)")
 
     # Save the frame to a file
-    frame_filename = f"frame_{frame_index:04d}.png"
-    plt.savefig(frame_filename, dpi=dpi)
-    plt.close(fig)
-
-    return frame_filename
-
+    with io.BytesIO() as io_buf:
+        fig.savefig(io_buf, format='raw', dpi=dpi)
+        return io_buf.getvalue()
 
 @cli.from_docstring(app, name="xyts")
 def animate_low_frequency(
@@ -565,8 +564,8 @@ def animate_low_frequency(
         `downsample` in the x and y direction. Provides a speedup for large
         domains.
     """
-    ffmpeg = shutil.which("ffmpeg")
-    if not ffmpeg:
+    have_ffmpeg = shutil.which("ffmpeg")
+    if not have_ffmpeg:
         print(
             "You must have ffmpeg installed. See https://ffmpeg.org/download.html.",
         )
@@ -593,67 +592,64 @@ def animate_low_frequency(
     frame_count = frame_count or xyts_file.nt
     xr, yr = waveform_coordinates(nztm_corners, xyts_file.nx, xyts_file.ny)
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        render_frame = functools.partial(
-            render_single_frame,
-            dt=xyts_file.dt,
-            shading=shading,
-            xyts_file_path = xyts_ffp.resolve(),
-            max_motion=max_motion,
-            cmap=cmap,
-            source_config=source_config,
-            nztm_corners=nztm_corners,
-            map_extent_nztm=map_extent_nztm,
-            xr=xr,
-            yr=yr,
-            simple_map=simple_map,
-            scale=scale,
-            map_quality=map_quality,
-            title=title,
-            width=width,
-            height=height,
-            dpi=dpi,
-            downsample=downsample
-        )
+    render_frame = functools.partial(
+        render_single_frame,
+        dt=xyts_file.dt,
+        shading=shading,
+        xyts_file_path = xyts_ffp.resolve(),
+        max_motion=max_motion,
+        cmap=cmap,
+        source_config=source_config,
+        nztm_corners=nztm_corners,
+        map_extent_nztm=map_extent_nztm,
+        xr=xr,
+        yr=yr,
+        simple_map=simple_map,
+        scale=scale,
+        map_quality=map_quality,
+        title=title,
+        width=width,
+        height=height,
+        dpi=dpi,
+        downsample=downsample
+    )
 
-        # warm the OSM cache to speed up rendering by rendering the first frame
-        os.chdir(temp_dir)
+    # warm the OSM cache to speed up rendering by rendering the first frame
 
-        render_frame(0)
+    frames = [render_frame(0)]
 
-        with mp.Pool() as pool:
-            # Render all frames in parallel
-            _ = list(
-                tqdm.tqdm(
-                    pool.imap(render_frame, range(frame_start, frame_start + frame_count)),
-                    total=frame_count,
-                    unit="frame",
-                    desc="Rendering frames",
-                    initial=1,
-                )
+    with mp.Pool() as pool:
+        # Render all frames in parallel
+        frames.extend(
+            tqdm.tqdm(
+                pool.imap(render_frame, range(frame_start, frame_start + frame_count)),
+                total=frame_count,
+                unit="frame",
+                desc="Rendering frames",
+                initial=1,
             )
+        )
+    cm = 1/2.54
+    width_px = int(width * cm * dpi)
+    height_px = int(height * cm * dpi)
+    # Use ffmpeg to combine frames into video
+    process = (
+        ffmpeg
+        .input('pipe:0', format='rawvideo', pix_fmt='rgba', s=f'{width_px}x{height_px}')
+        .output(str(output_mp4), pix_fmt='yuv420p', r=fps, vcodec='libx264', crf=23, vf='pad=ceil(iw/2)*2:ceil(ih/2)*2')
+        .overwrite_output()
+        .run_async(pipe_stdin=True)
+    )
 
-        # Use ffmpeg to combine frames into video
+    # Write the raw video data to FFmpeg's stdin
+    for frame in frames:
+        process.stdin.write(frame)
 
-        ffmpeg_cmd = [
-            ffmpeg,
-            "-y",  # Overwrite output file if it exists
-            "-framerate",
-            str(fps),
-            "-i",
-            "frame_%04d.png",
-            "-c:v",
-            "libx264",
-            "-vf",
-            "pad=ceil(iw/2)*2:ceil(ih/2)*2",
-            "-pix_fmt",
-            "yuv420p",
-            "-crf",
-            "23",  # Quality setting (lower is better)
-            str(output_mp4),
-        ]
+    process.stdin.close()
 
-        subprocess.run(ffmpeg_cmd, check=True)
+    # Wait for FFmpeg to finish
+    process.wait()
+
 
 
 def non_zero_data_points(

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -439,14 +439,10 @@ def render_single_frame(
     pcm = ax.pcolormesh(
         yr[::downsample, ::downsample],
         xr[::downsample, ::downsample],
-        current_data[::downsample, ::downsample],
-        cmap=cmap,
-        vmin=0,
-        vmax=max_motion,
+        apply_cmap_with_alpha(current_data[::downsample, ::downsample], 0, max_motion),
         shading="gouraud",
         zorder=3,
         transform=NZTM_CRS,
-
     )
 
     # Add time text

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -1,12 +1,9 @@
 """Create simulation video of surface ground motion levels."""
 
 import functools
-import multiprocessing as mp
 import io
-import os
+import multiprocessing as mp
 import shutil
-import subprocess
-import tempfile
 from pathlib import Path
 from typing import Annotated
 
@@ -17,10 +14,10 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import ffmpeg
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
-import ffmpeg
 import shapely
 import tqdm
 import typer
@@ -313,6 +310,7 @@ def waveform_coordinates(nztm_corners: np.ndarray, nx: int, ny: int) -> np.ndarr
     )
     return coords_nztm[::-1, :, :]  # Reverse order to (x, y) for NZTM
 
+
 def tslice_get(xyts_file: XYTSFile, index: int, downsample: int = 1) -> np.ndarray:
     """Retrieve a single timeslice from an xyts file with downsampling
 
@@ -337,6 +335,7 @@ def tslice_get(xyts_file: XYTSFile, index: int, downsample: int = 1) -> np.ndarr
         frame_data = xyts_file.data[index]  # shape: (3, ny, nx)
     return np.linalg.norm(frame_data, axis=0)
 
+
 def render_single_frame(
     frame_index: int,
     dt: float,
@@ -356,7 +355,7 @@ def render_single_frame(
     width: float,
     height: float,
     dpi: int,
-    downsample: int
+    downsample: int,
 ) -> bytes:
     """Render a single frame of the animation.
 
@@ -462,7 +461,9 @@ def render_single_frame(
         yr[::downsample, ::downsample],
         xr[::downsample, ::downsample],
         apply_cmap_with_alpha(current_data, 0, max_motion, cmap=cmap),
-        cmap=cmap, vmin=0, vmax=max_motion,
+        cmap=cmap,
+        vmin=0,
+        vmax=max_motion,
         shading=shading,
         zorder=3,
         transform=NZTM_CRS,
@@ -488,13 +489,18 @@ def render_single_frame(
 
     plt.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
     cbar = fig.colorbar(
-        pcm, ax=ax, orientation="vertical", pad=0.02, aspect=30, shrink=0.8,
+        pcm,
+        ax=ax,
+        orientation="vertical",
+        pad=0.02,
+        aspect=30,
+        shrink=0.8,
     )
     cbar.set_label("Ground Motion (cm/s)")
 
     # Save the frame to a file
     with io.BytesIO() as io_buf:
-        fig.savefig(io_buf, format='raw', dpi=dpi)
+        fig.savefig(io_buf, format="raw", dpi=dpi)
         plt.close(fig)
         return io_buf.getvalue()
 
@@ -521,7 +527,7 @@ def animate_low_frequency(
     zoom: Annotated[float, typer.Option()] = 1,
     simple_map: Annotated[bool, typer.Option()] = False,
     map_quality: Annotated[int, typer.Option()] = 4,
-    downsample: Annotated[int, typer.Option()] = 1
+    downsample: Annotated[int, typer.Option()] = 1,
 ) -> None:
     """Render low-frequency output as a 2D video of ground motions.
 
@@ -602,7 +608,7 @@ def animate_low_frequency(
         render_single_frame,
         dt=xyts_file.dt,
         shading=shading,
-        xyts_file_path = xyts_ffp.resolve(),
+        xyts_file_path=xyts_ffp.resolve(),
         max_motion=max_motion,
         cmap=cmap,
         source_config=source_config,
@@ -617,7 +623,7 @@ def animate_low_frequency(
         width=width,
         height=height,
         dpi=dpi,
-        downsample=downsample
+        downsample=downsample,
     )
 
     # warm the OSM cache to speed up rendering by rendering the first frame
@@ -635,14 +641,22 @@ def animate_low_frequency(
                 initial=1,
             )
         )
-    cm = 1/2.54
+    cm = 1 / 2.54
     width_px = int(width * cm * dpi)
     height_px = int(height * cm * dpi)
     # Use ffmpeg to combine frames into video
     process = (
-        ffmpeg
-        .input('pipe:0', format='rawvideo', pix_fmt='rgba', s=f'{width_px}x{height_px}')
-        .output(str(output_mp4), pix_fmt='yuv420p', r=fps, vcodec='libx264', crf=23, vf='pad=ceil(iw/2)*2:ceil(ih/2)*2')
+        ffmpeg.input(
+            "pipe:0", format="rawvideo", pix_fmt="rgba", s=f"{width_px}x{height_px}"
+        )
+        .output(
+            str(output_mp4),
+            pix_fmt="yuv420p",
+            r=fps,
+            vcodec="libx264",
+            crf=23,
+            vf="pad=ceil(iw/2)*2:ceil(ih/2)*2",
+        )
         .overwrite_output()
         .run_async(pipe_stdin=True)
     )
@@ -655,7 +669,6 @@ def animate_low_frequency(
 
     # Wait for FFmpeg to finish
     process.wait()
-
 
 
 def non_zero_data_points(

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -339,13 +339,14 @@ def render_single_frame(
     frame_index: int,
     dt: float,
     xyts_file_path: Path,
-    max_motion: float,
-    cmap: str,
     source_config: SourceConfig,
     nztm_corners: np.ndarray,
     map_extent_nztm: tuple[float, float, float, float],
     xr: np.ndarray,
     yr: np.ndarray,
+    max_motion: float,
+    cmap: str,
+    shading: str,
     simple_map: bool,
     scale: str,
     map_quality: int,
@@ -353,7 +354,7 @@ def render_single_frame(
     width: float,
     height: float,
     dpi: int,
-    downsample
+    downsample: int
 ) -> str:
     """Render a single frame of the animation.
 
@@ -452,8 +453,9 @@ def render_single_frame(
     pcm = ax.pcolormesh(
         yr[::downsample, ::downsample],
         xr[::downsample, ::downsample],
-        apply_cmap_with_alpha(current_data[::downsample, ::downsample], 0, max_motion),
-        shading="gouraud",
+        apply_cmap_with_alpha(current_data[::downsample, ::downsample], 0, max_motion, cmap=cmap),
+        cmap=cmap, vmin=0, vmax=max_motion,
+        shading=shading,
         zorder=3,
         transform=NZTM_CRS,
     )
@@ -478,7 +480,7 @@ def render_single_frame(
 
     plt.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
     cbar = fig.colorbar(
-        pcm, ax=ax, orientation="vertical", pad=0.02, aspect=30, shrink=0.8
+        pcm, ax=ax, orientation="vertical", pad=0.02, aspect=30, shrink=0.8,
     )
     cbar.set_label("Ground Motion (cm/s)")
 
@@ -587,6 +589,7 @@ def animate_low_frequency_mpl_nztm(
         render_frame = functools.partial(
             render_single_frame,
             dt=xyts_file.dt,
+            shading=shading,
             xyts_file_path = xyts_ffp.resolve(),
             max_motion=max_motion,
             cmap=cmap,

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -437,15 +437,16 @@ def render_single_frame(
 
     current_data = tslice_get(xyts_file, frame_index)
     pcm = ax.pcolormesh(
-        xr[0, ::downsample],
         yr[::downsample, ::downsample],
-        apply_cmap_with_alpha(current_data[::downsample, ::downsample], 0, max_motion, cmap=cmap),
+        xr[::downsample, ::downsample],
+        current_data[::downsample, ::downsample],
         cmap=cmap,
         vmin=0,
         vmax=max_motion,
         shading="gouraud",
         zorder=3,
-        rasterized=True,
+        transform=NZTM_CRS,
+
     )
 
     # Add time text

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -312,15 +312,28 @@ def waveform_coordinates(nztm_corners: np.ndarray, nx: int, ny: int) -> np.ndarr
     return coords_nztm[::-1, :, :]  # Reverse order to (x, y) for NZTM
 
 def tslice_get(xyts_file: XYTSFile, index: int, downsample: int = 1) -> np.ndarray:
+    """Retreive a single timeslice from an xyts file with downsampling
+
+    Parameters
+    ----------
+    xyts_file : XYTSFile
+        The xyts file to retreive from.
+    index : int
+        The timeslice index to read from.
+    downsample : int
+        If greater than 1, downsample the array in strides of `downsample` in
+        the x and y direction.
+
+    Returns
+    -------
+    array of float32
+        An array of shape (ny, nx) containing the downsampled frame data for `index`.
+    """
     if downsample > 1:
         frame_data = xyts_file.data[index, :, ::downsample, ::downsample]
     else:
         frame_data = xyts_file.data[index]  # shape: (3, ny, nx)
-    accum = np.zeros(frame_data.shape[1:], dtype=np.float32)
-    for i in range(3):
-        np.add(accum, frame_data[i] ** 2, out=accum)
-    np.sqrt(accum, out=accum)
-    return accum
+    return np.linalg.norm(frame_data, axis=0)
 
 def render_single_frame(
     frame_index: int,

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -597,7 +597,7 @@ def animate_low_frequency_mpl_nztm(
 
         render_frame(0)
 
-        with mp.Pool(4) as pool:
+        with mp.Pool() as pool:
             # Render all frames in parallel
             _ = list(
                 tqdm.tqdm(

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -366,6 +366,8 @@ def render_single_frame(
         The index of the frame to render.
     dt : float
         The time step of the simulation.
+    xyts_file_path : Path
+        The path to the XYTS file.
     source_config : SourceConfig
         The source configuration object.
     nztm_corners : np.ndarray
@@ -543,6 +545,8 @@ def animate_low_frequency(
         The shading method for `plt.pcolormesh`, by default "gouraud".
     frame_count : int | None, optional
         The number of frames to display in the animation, by default None (uses all frames).
+    frame_start : int, optional
+        The frame to start the animation on. Defaults to zero.
     width : float, optional
         The width of the figure in cm, by default 30.
     height : float, optional

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -312,12 +312,12 @@ def waveform_coordinates(nztm_corners: np.ndarray, nx: int, ny: int) -> np.ndarr
     return coords_nztm[::-1, :, :]  # Reverse order to (x, y) for NZTM
 
 def tslice_get(xyts_file: XYTSFile, index: int, downsample: int = 1) -> np.ndarray:
-    """Retreive a single timeslice from an xyts file with downsampling
+    """Retrieve a single timeslice from an xyts file with downsampling
 
     Parameters
     ----------
     xyts_file : XYTSFile
-        The xyts file to retreive from.
+        The xyts file to retrieve from.
     index : int
         The timeslice index to read from.
     downsample : int

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -340,6 +340,7 @@ def render_single_frame(
     width: float,
     height: float,
     dpi: int,
+    downsample
 ) -> str:
     """Render a single frame of the animation.
 
@@ -436,9 +437,9 @@ def render_single_frame(
 
     current_data = tslice_get(xyts_file, frame_index)
     pcm = ax.pcolormesh(
-        xr[0],
-        yr,
-        apply_cmap_with_alpha(current_data, 0, max_motion, cmap=cmap),
+        xr[0, ::downsample],
+        yr[::downsample, ::downsample],
+        apply_cmap_with_alpha(current_data[::downsample, ::downsample], 0, max_motion, cmap=cmap),
         cmap=cmap,
         vmin=0,
         vmax=max_motion,
@@ -501,6 +502,7 @@ def animate_low_frequency_mpl_nztm(
     zoom: Annotated[float, typer.Option()] = 1,
     simple_map: Annotated[bool, typer.Option()] = False,
     map_quality: Annotated[int, typer.Option()] = 4,
+    downsample: int = 1
 ) -> None:
     """Render low-frequency output as a 2D video of ground motions.
 
@@ -590,6 +592,7 @@ def animate_low_frequency_mpl_nztm(
             width=width,
             height=height,
             dpi=dpi,
+            downsample=downsample
         )
 
         # warm the OSM cache to speed up rendering by rendering the first frame

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -493,7 +493,7 @@ def render_single_frame(
     # Save the frame to a file
     with io.BytesIO() as io_buf:
         fig.savefig(io_buf, format='raw', dpi=dpi)
-        fig.close()
+        plt.close(fig)
         return io_buf.getvalue()
 
 

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -453,11 +453,11 @@ def render_single_frame(
 
     # Add the actual data for this frame
 
-    current_data = tslice_get(xyts_file, frame_index)
+    current_data = tslice_get(xyts_file, frame_index, downsample=downsample)
     pcm = ax.pcolormesh(
         yr[::downsample, ::downsample],
         xr[::downsample, ::downsample],
-        apply_cmap_with_alpha(current_data[::downsample, ::downsample], 0, max_motion, cmap=cmap),
+        apply_cmap_with_alpha(current_data, 0, max_motion, cmap=cmap),
         cmap=cmap, vmin=0, vmax=max_motion,
         shading=shading,
         zorder=3,

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -311,11 +311,21 @@ def waveform_coordinates(nztm_corners: np.ndarray, nx: int, ny: int) -> np.ndarr
     )
     return coords_nztm[::-1, :, :]  # Reverse order to (x, y) for NZTM
 
+def tslice_get(xyts_file: XYTSFile, index: int, downsample: int = 1) -> np.ndarray:
+    if downsample > 1:
+        frame_data = xyts_file.data[index, :, ::downsample, ::downsample]
+    else:
+        frame_data = xyts_file.data[index]  # shape: (3, ny, nx)
+    accum = np.zeros(frame_data.shape[1:], dtype=np.float32)
+    for i in range(3):
+        np.add(accum, frame_data[i] ** 2, out=accum)
+    np.sqrt(accum, out=accum)
+    return accum
 
 def render_single_frame(
     frame_index: int,
     dt: float,
-    ground_motion_magnitude: np.ndarray,
+    xyts_file_path: Path,
     max_motion: float,
     cmap: str,
     source_config: SourceConfig,
@@ -375,6 +385,7 @@ def render_single_frame(
     str
         The filename of the saved frame.
     """
+    xyts_file = XYTSFile(xyts_file_path)
     # Create a new figure for this frame
     cm = 1 / 2.54
     fig = plt.figure(figsize=(width * cm, height * cm))
@@ -422,9 +433,10 @@ def render_single_frame(
     )
 
     # Add the actual data for this frame
-    current_data = ground_motion_magnitude[frame_index, :, :]
+
+    current_data = tslice_get(xyts_file, frame_index)
     pcm = ax.pcolormesh(
-        xr,
+        xr[0],
         yr,
         apply_cmap_with_alpha(current_data, 0, max_motion, cmap=cmap),
         cmap=cmap,
@@ -480,6 +492,7 @@ def animate_low_frequency_mpl_nztm(
     scale: Annotated[str, typer.Option()] = "10m",
     shading: Annotated[str, typer.Option()] = "gouraud",
     frame_count: Annotated[int | None, typer.Option()] = None,
+    frame_start: Annotated[int, typer.Option()] = 0,
     width: Annotated[float, typer.Option()] = 30.0,
     height: Annotated[float, typer.Option()] = 30.0,
     dpi: Annotated[int, typer.Option()] = 150,
@@ -540,8 +553,6 @@ def animate_low_frequency_mpl_nztm(
     source_config = SourceConfig.read_from_realisation(realisation_ffp)
     xyts_file = XYTSFile(xyts_ffp)
 
-    ground_motion_magnitude = np.linalg.norm(xyts_file.data, axis=1)
-
     nztm_corners = xyts_nztm_corners(xyts_file)
     map_extent_nztm = map_extents(nztm_corners, padding)
 
@@ -564,7 +575,7 @@ def animate_low_frequency_mpl_nztm(
         render_frame = functools.partial(
             render_single_frame,
             dt=xyts_file.dt,
-            ground_motion_magnitude=ground_motion_magnitude,
+            xyts_file_path = xyts_ffp.resolve(),
             max_motion=max_motion,
             cmap=cmap,
             source_config=source_config,
@@ -586,11 +597,11 @@ def animate_low_frequency_mpl_nztm(
 
         render_frame(0)
 
-        with mp.Pool() as pool:
+        with mp.Pool(4) as pool:
             # Render all frames in parallel
             _ = list(
                 tqdm.tqdm(
-                    pool.imap(render_frame, range(1, frame_count)),
+                    pool.imap(render_frame, range(frame_start, frame_start + frame_count)),
                     total=frame_count,
                     unit="frame",
                     desc="Rendering frames",

--- a/visualisation/plot_ts.py
+++ b/visualisation/plot_ts.py
@@ -364,12 +364,6 @@ def render_single_frame(
         The index of the frame to render.
     dt : float
         The time step of the simulation.
-    ground_motion_magnitude : np.ndarray
-        The ground motion magnitude data.
-    max_motion : float
-        The maximum ground motion value for color scaling.
-    cmap : str
-        The colormap to use for the animation.
     source_config : SourceConfig
         The source configuration object.
     nztm_corners : np.ndarray
@@ -380,6 +374,12 @@ def render_single_frame(
         The x coordinates of the gridpoints in NZTM coordinates.
     yr : np.ndarray
         The y coordinates of the gridpoints in NZTM coordinates.
+    max_motion : float
+        The maximum ground motion value for color scaling.
+    cmap : str
+        The colormap to use for the animation.
+    shading : str
+        The shading to apply to the colourmap.
     simple_map : bool
         If True, disable OpenStreetMap background and use a simple map.
     scale : str
@@ -394,6 +394,10 @@ def render_single_frame(
         The height of the figure in cm.
     dpi : int
         The DPI for the figure.
+    downsample : int, optional
+        If greater than 1, downsample the timeslice array in strides of
+        `downsample` in the x and y direction. Provides a speedup for large
+        domains.
 
     Returns
     -------
@@ -493,7 +497,7 @@ def render_single_frame(
 
 
 @cli.from_docstring(app, name="xyts")
-def animate_low_frequency_mpl_nztm(
+def animate_low_frequency(
     realisation_ffp: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
     xyts_ffp: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
     output_mp4: Annotated[
@@ -556,6 +560,10 @@ def animate_low_frequency_mpl_nztm(
     map_quality : int, optional
         The quality of the map, by default 4. Has no effect if using a
         simple map. Lower values have lower quality but render faster.
+    downsample : int, optional
+        If greater than 1, downsample the timeslice array in strides of
+        `downsample` in the x and y direction. Provides a speedup for large
+        domains.
     """
     ffmpeg = shutil.which("ffmpeg")
     if not ffmpeg:


### PR DESCRIPTION
This PR improves the speed of `plot-ts` to reduce the memory usage and time this script takes to run. Average frame generation speeds have reduced from ~5 seconds per frame to 10 frames per second on Hypocentre, a 50x speedup.

The main achievements to do this are:

1. Properly parallelise the main loop without copying as much between threads.
2. Making memmap access patterns more efficient.
3. Introducing a downsampling option for the waveform mesh.