### PR TITLE
Use a dynamically determined grid scale for a region based on size

### DIFF
--- a/visualisation/sources/plot_rise.py
+++ b/visualisation/sources/plot_rise.py
@@ -53,12 +53,12 @@ def plot_rise(
     fig = plotting.gen_region_fig(
         title, projection=f"M{width}c", region=region, map_data=None
     )
-
+    grid_scale = plotting.grid_scale_for_region(region)
     for i, segment_points in enumerate(srf_data.segments):
         cur_grid = plotting.create_grid(
             segment_points,
             "trise",
-            grid_spacing="5e/5e",
+            grid_spacing=f"{grid_scale}e/{grid_scale}e",
             region=(
                 segment_points["lon"].min(),
                 segment_points["lon"].max(),
@@ -82,7 +82,7 @@ def plot_rise(
         time_grid = plotting.create_grid(
             segment_points,
             "tinit",
-            grid_spacing="5e/5e",
+            grid_spacing=f"{grid_scale}e/{grid_scale}e",
             region=(
                 segment_points["lon"].min(),
                 segment_points["lon"].max(),

--- a/visualisation/sources/plot_srf.py
+++ b/visualisation/sources/plot_srf.py
@@ -119,6 +119,7 @@ def show_slip(
     )
     dx = srf_data.header.iloc[0]["len"] / srf_data.header.iloc[0]["nstk"]
     subtitle = f"Slip: {slip_stats}, dx = {dx:.2f} km, {len(srf_data.header)} planes"
+    grid_scale = grid_scale_for_region(region)
     for (_, segment), segment_points in zip(
         srf_data.header.iterrows(), srf_data.segments
     ):
@@ -129,7 +130,7 @@ def show_slip(
         cur_grid = plotting.create_grid(
             segment_points,
             "slip",
-            grid_spacing="5e/5e",
+            grid_spacing=f"{grid_scale}e/{grid_scale}e",
             region=(
                 segment_points["lon"].min(),
                 segment_points["lon"].max(),
@@ -156,7 +157,7 @@ def show_slip(
         time_grid = plotting.create_grid(
             segment_points,
             "tinit",
-            grid_spacing="5e/5e",
+            grid_spacing=f"{grid_scale}e/{grid_scale}e",
             region=(
                 segment_points["lon"].min(),
                 segment_points["lon"].max(),

--- a/visualisation/utils.py
+++ b/visualisation/utils.py
@@ -292,3 +292,27 @@ def bounding_region_for(
         min_latitude - latitude_pad,
         max_latitude + latitude_pad,
     )
+
+
+def grid_scale_for_region(region: tuple[float, float, float, float]) -> float:
+    """Compute a suitable grid scale for a pygmt region.
+
+    Parameters
+    ----------
+    region : tuple[float, float, float, float]
+        The pygmt region you will plot a grid in.
+
+    Returns
+    -------
+    int
+        A value (in metres) represent for `plotting.create_grid` to
+        use when plotting the lat-lon grid. Scale is based on the
+        maximum extent in the lat or lon direction for the figure in
+        kilometres. Works out that 10km = 25m, 100km = 250m, with a
+        minimum resolution of 5m.
+    """
+    min_lon, max_lon, min_lat, max_lat = region
+    lat_km = (max_lat - min_lat) * 111
+    lon_km = 111 * np.cos(np.radians((min_lat + max_lat) / 2))
+    maximum_extent = max(lat_km, lon_km)
+    return int(round(max(5, 2.5 * maximum_extent)))


### PR DESCRIPTION
This small change adds a utility function `grid_scale_for_region` that computes an appropriate grid scale for the region of the pygmt map which we use for the grid spacing in `plotting.create_grid`. The equation is $\mathrm{max}(5, 2.5x)$, where $x$ is the largest extent (in km) of the region in latitude or longitude. Did this so I can make SRF plots without taking 20 minutes.